### PR TITLE
Added scene reset when screen catches up or player falls below screen

### DIFF
--- a/src/scene/horizontal_scene.h
+++ b/src/scene/horizontal_scene.h
@@ -41,8 +41,9 @@ private:
 
     void create_background(Blackboard &blackboard);
     void create_panda(Blackboard& blackboard);
-    void reset_scene(Blackboard& blackboard, entt::DefaultRegistry &registry);
+    void reset_scene(Blackboard& blackboard);
     void init_scene(Blackboard &blackboard);
+    void update_panda(Blackboard& blackboard);
 
 public:
     HorizontalScene(Blackboard &blackboard,

--- a/src/systems/horizontal_level_system.cpp
+++ b/src/systems/horizontal_level_system.cpp
@@ -9,7 +9,7 @@
 #include "horizontal_level_system.h"
 
 HorizontalLevelSystem::HorizontalLevelSystem(): LevelSystem() {
-
+    last_col_placed_ = FIRST_COL_X;
 }
 
 void HorizontalLevelSystem::load_next_chunk() {
@@ -50,6 +50,7 @@ void HorizontalLevelSystem::destroy_entities(entt::DefaultRegistry &registry) {
         registry.destroy(platform);
         platform_entities_.pop();
     }
+    last_col_placed_ = FIRST_COL_X;
 }
 
 void HorizontalLevelSystem::update(Blackboard &blackboard, entt::DefaultRegistry &registry) {

--- a/src/systems/horizontal_level_system.h
+++ b/src/systems/horizontal_level_system.h
@@ -13,6 +13,8 @@ class HorizontalLevelSystem : public LevelSystem {
 
     void generate_next_chunk(Blackboard &blackboard, entt::DefaultRegistry &registry);
 
+    const float FIRST_COL_X = -200;
+
 public:
 
     HorizontalLevelSystem();


### PR DESCRIPTION
This also removes an unnecessary argument from reset_scene in HorizontalScene. Let's merge this in to feature/better-level-design before merging #70 into master. 