### PR TITLE
Commented out code in mesh destructor to allow single sprites to be destroyed

### DIFF
--- a/src/graphics/mesh.cpp
+++ b/src/graphics/mesh.cpp
@@ -20,9 +20,10 @@ Mesh::Mesh(size_t vertex_count, TexturedVertex *vertices, size_t index_count, ui
 }
 
 Mesh::~Mesh() {
-    glDeleteBuffers(1, &vbo_);
-    glDeleteBuffers(1, &ibo_);
-    glDeleteBuffers(1, &vao_);
+    // Commented out as a temporary fix for destroying single entities
+//    glDeleteBuffers(1, &vbo_);
+//    glDeleteBuffers(1, &ibo_);
+//    glDeleteBuffers(1, &vao_);
 }
 
 void Mesh::bind() {


### PR DESCRIPTION
For the boss scene and continuously deleting off-screen entities in the level, we need to be allowed to destroy single entities without destroying everything on screen. This is a temporary leaky fix to allow this. I'll make an issue to make a non-leaky fix for this. 