### PR TITLE
Hackily removed score from story mode.

### DIFF
--- a/src/scene/horizontal_scene.cpp
+++ b/src/scene/horizontal_scene.cpp
@@ -136,7 +136,11 @@ void HorizontalScene::render(Blackboard &blackboard) {
     cave_render_system.update(blackboard, registry_);
     sprite_render_system.update(blackboard, registry_);
     health_bar_render_system.update(blackboard, registry_);
-    text_render_system.update(blackboard, registry_);
+
+    // This if is for hiding the score in STORY mode
+    // TODO: Remove this hackiness, especially if we need some other text in story mode
+    if (mode_ == ENDLESS)
+        text_render_system.update(blackboard, registry_);
 
     auto &panda = registry_.get<Panda>(panda_entity);
     auto &interactable = registry_.get<Interactable>(panda_entity);
@@ -249,6 +253,7 @@ void HorizontalScene::create_score_text(Blackboard &blackboard) {
 }
 
 void HorizontalScene::set_mode(SceneMode mode) {
+    Scene::set_mode(mode);
     level_system.set_mode(mode);
 }
 

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -15,5 +15,5 @@ bool Scene::change_scene(SceneID id) {
 }
 
 void Scene::set_mode(SceneMode mode) {
-
+    mode_ = mode;
 }

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -23,6 +23,7 @@ private:
 
 protected:
     entt::DefaultRegistry registry_;
+    SceneMode mode_;
 
 public:
     Scene(SceneManager& scene_manager);

--- a/src/scene/vertical_scene.cpp
+++ b/src/scene/vertical_scene.cpp
@@ -165,7 +165,11 @@ void VerticalScene::render(Blackboard &blackboard) {
     background_render_system.update(blackboard, registry_);
     sprite_render_system.update(blackboard, registry_);
     health_bar_render_system.update(blackboard, registry_);
-    text_render_system.update(blackboard, registry_);
+
+    // This if is for hiding the score in STORY mode
+    // TODO: Remove this hackiness, especially if we need some other text in story mode
+    if (mode_ == ENDLESS)
+        text_render_system.update(blackboard, registry_);
 
     auto &panda = registry_.get<Panda>(panda_entity);
     auto &interactable = registry_.get<Interactable>(panda_entity);
@@ -242,6 +246,7 @@ void VerticalScene::create_score_text(Blackboard &blackboard) {
 }
 
 void VerticalScene::set_mode(SceneMode mode) {
+    Scene::set_mode(mode);
     level_system.set_mode(mode);
 }
 


### PR DESCRIPTION
All this does is stop any text from being rendered which works since I believe our only text is score. LMK if there is other text I am forgetting about. We should probably change this later.